### PR TITLE
Add RDBMS specific xml migration supports (just like SqlMigration)

### DIFF
--- a/src/main/java/io/github/gitbucket/solidbase/migration/LiquibaseMigration.java
+++ b/src/main/java/io/github/gitbucket/solidbase/migration/LiquibaseMigration.java
@@ -57,13 +57,26 @@ public class LiquibaseMigration implements Migration {
     protected void migrate(Connection conn, Database database, ClassLoader classLoader,
                            String moduleId, String version, Map<String, Object> context) throws Exception {
 
-        String path = this.path;
-        if(path == null){
-            path = moduleId + "_" + version + ".xml";
+        List<String> fileNames = new ArrayList<>();
+        if(this.path != null){
+            if(this.path.endsWith(".xml")){
+                fileNames.add(this.path.replaceFirst("\\.xml$", "_" + database.getShortName() + ".xml"));
+            }
+            fileNames.add(this.path);
         }
+        fileNames.add(moduleId + "_" + version + "_" + database.getShortName() + ".xml");
+        fileNames.add(moduleId + "_" + version + ".xml");
 
-        String source = MigrationUtils.readResourceAsString(classLoader, path);
-
+        String path = null;
+        String source = null;
+        for(String fileName: fileNames){
+            source = MigrationUtils.readResourceAsString(classLoader, fileName);
+            if(source != null){
+                path = fileName; 
+                break;
+            }
+        }
+        
         Liquibase liquibase = new Liquibase(path, new StringResourceAccessor(path,
                 new LiquibaseXmlPreProcessor().preProcess(moduleId, version, source), classLoader), database);
 


### PR DESCRIPTION
Currently SqlMigration support this feature.
In some cases, this feature is useful  for Liquidbase XML migration too.

I know Liquibase supports conditional changeset by RDBMS type.
<http://www.liquibase.org/documentation/preconditions.html>

but it require existing xml change and may cause a side effect.
so I want to use separated DBMS specific xml migration.

Note: 
I'm investigating GitBucket DB hosting on Microsoft SQL Server.
but there are some incompatible settings. and require xml modifications.
