### PR TITLE
Downgrade maven-source-plugin to 3.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.apache.maven.plugins:maven-source-plugin"

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>source-jar</id>


### PR DESCRIPTION
Avoid the following error temporarily to release solidbase 1.1.0.

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.1:jar (source-jar) on project solidbase: Presumably you have configured maven-source-plugin to execute twice in your build. You have to configure a classifier for at least one of them. -> [Help 1]

https://issues.apache.org/jira/browse/MSOURCES-121