### PR TITLE
Add VersionManager::findCurrentVersion

### DIFF
--- a/src/main/java/io/github/gitbucket/solidbase/manager/JDBCVersionManager.java
+++ b/src/main/java/io/github/gitbucket/solidbase/manager/JDBCVersionManager.java
@@ -5,6 +5,7 @@ import static io.github.gitbucket.solidbase.migration.MigrationUtils.*;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.util.Optional;
 
 /**
  * Created by takezoe on 15/11/23.
@@ -35,6 +36,15 @@ public class JDBCVersionManager implements VersionManager {
     @Override
     public String getCurrentVersion(String moduleId) throws Exception {
         return selectStringFromDatabase(conn, "SELECT VERSION FROM VERSIONS WHERE MODULE_ID = ?", moduleId);
+    }
+
+    @Override
+    public Optional<String> findCurrentVersion(String moduleId) throws Exception {
+        if (!checkTableExist()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(getCurrentVersion(moduleId));
+        }
     }
 
     protected boolean checkTableExist(){

--- a/src/main/java/io/github/gitbucket/solidbase/manager/VersionManager.java
+++ b/src/main/java/io/github/gitbucket/solidbase/manager/VersionManager.java
@@ -1,5 +1,7 @@
 package io.github.gitbucket.solidbase.manager;
 
+import java.util.Optional;
+
 public interface VersionManager {
 
     void initialize() throws Exception;
@@ -7,5 +9,7 @@ public interface VersionManager {
     void updateVersion(String moduleId, String version) throws Exception;
 
     String getCurrentVersion(String moduleId) throws Exception;
+
+    Optional<String> findCurrentVersion(String moduleId) throws Exception;
 
 }

--- a/src/test/java/io/github/gitbucket/solidbase/manager/JDBCVersionManagerTest.java
+++ b/src/test/java/io/github/gitbucket/solidbase/manager/JDBCVersionManagerTest.java
@@ -1,0 +1,40 @@
+package io.github.gitbucket.solidbase.manager;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class JDBCVersionManagerTest {
+
+    @Test(expected = Exception.class)
+    public void testGetCurrentVersionThrowsWhenVersionsTableIsMissing() throws Exception {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test-getCurrentVersion-missing-table", "sa", "sa")) {
+            JDBCVersionManager manager = new JDBCVersionManager(conn);
+            manager.getCurrentVersion("test");
+        }
+    }
+
+    @Test
+    public void testFindCurrentVersionIsEmptyWhenVersionsTableIsMissing() throws Exception {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test-findCurrentVersion-missing-table", "sa", "sa")) {
+            JDBCVersionManager manager = new JDBCVersionManager(conn);
+
+            assertEquals(Optional.empty(), manager.findCurrentVersion("test"));
+        }
+    }
+
+    @Test
+    public void testFindCurrentVersionReturnsVersionWhenVersionsTableIsPresent() throws Exception {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test-findCurrentVersion-present-table", "sa", "sa")) {
+            JDBCVersionManager manager = new JDBCVersionManager(conn);
+            manager.initialize();
+            manager.updateVersion("test", "1.0.0");
+
+            assertEquals(Optional.of("1.0.0"), manager.findCurrentVersion("test"));
+        }
+    }
+}


### PR DESCRIPTION
Add a minimalist of a variant of `getCurrentVersion` that when the version table does not exist returns empty instead of throwing an exception.

This makes it easy to detect when no migrations have been applied yet.